### PR TITLE
add ability to pass config via env-var

### DIFF
--- a/SpiderKeeper/app/config.py
+++ b/SpiderKeeper/app/config.py
@@ -37,6 +37,6 @@ SERVERS = ['http://localhost:6800']
 
 # basic auth
 NO_AUTH = False
-BASIC_AUTH_USERNAME = 'admin'
-BASIC_AUTH_PASSWORD = 'admin'
+BASIC_AUTH_USERNAME = os.environ.get('USERNAME', None)
+BASIC_AUTH_PASSWORD = os.environ.get('PASSWORD', None)
 BASIC_AUTH_FORCE = True

--- a/SpiderKeeper/scrapyd/app.py
+++ b/SpiderKeeper/scrapyd/app.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import os
 from scrapyd.app import application as create_scrapyd_application
 from twisted.web.wsgi import WSGIResource
 from twisted.internet import reactor
@@ -9,10 +9,11 @@ from SpiderKeeper.scheduler import run_scheduler
 
 
 def create_spiderkeeper_application(scrapyd_config, flask_config=default_config):
+    REACTOR_PORT = int(os.environ.get('REACTOR_PORT', 5000))
     flask_app = create_flask_application(flask_config)
     run_scheduler(flask_app)
     app = create_scrapyd_application(scrapyd_config)
     resource = WSGIResource(reactor, reactor.getThreadPool(), flask_app)
     site = Site(resource)
-    reactor.listenTCP(5000, site)
+    reactor.listenTCP(REACTOR_PORT, site)
     return app


### PR DESCRIPTION
Hello, 

this merge request contains enhancement to alter `USERNAME`, `PASSWORD` for basic auth; and `REACTOR_PORT` that define port for spiderkeeper-2 to bind into.

in short, now we can do like this:

`$ USERNAME=widnyana PASSWORD=secret REACTOR_POOL=9999 spiderkeeper`
